### PR TITLE
vimc-7404 Add api email config to production

### DIFF
--- a/production/montagu.yml
+++ b/production/montagu.yml
@@ -39,8 +39,8 @@ api:
     name: montagu-cli
     tag: master
   email:
-    password: VAULT:secret/vimc/email/password
-    flow_url: VAULT:secret/vimc/flow/montagu_webhook
+    password: VAULT:secret/vimc/email/password:value
+    flow_url: VAULT:secret/vimc/flow/montagu-webhook:value
 db:
   name: montagu-db
   tag: master

--- a/production/montagu.yml
+++ b/production/montagu.yml
@@ -38,6 +38,9 @@ api:
   admin:
     name: montagu-cli
     tag: master
+  email:
+    password: VAULT:secret/vimc/email/password
+    flow_url: VAULT:secret/vimc/flow/montagu_webhook
 db:
   name: montagu-db
   tag: master


### PR DESCRIPTION
Email section config was missing from the api section of the production config - this should allow Teams notifications to be sent on burden estimate upload, and user notification emails to be sent, e.g. when a new user is created.

i deployed matching config to uat, and was able to get the Teams notification to show on [burden estimate upload](https://teams.microsoft.com/l/message/19:f796024d829e4675b07c3648f27e72e5@thread.tacv2/1721913573313?tenantId=2b897507-ee8c-4575-830b-4f8267c3d307&groupId=993c3b2e-8a31-496a-a485-eb466f411c31&parentMessageId=1721913573313&teamName=VIMC&channelName=Burden%20Estimates&createdTime=1721913573313).

I also received an email to my personal email address when I added that as a new user. 

The emails on diagnostic report should already have been configured correctly - however I struggled to test this on uat, partly because of OW api auth config not being set up correctly I think, but also because of issues with the YouTrack token from the vault (I think we saw this when we tried to deploy the other day). I'm not sure if a new token needs to be generated - did the old one expire? I do have a token which seems to work - should I just replace the token in the vault with that?