### PR TITLE
Enable automatic certificates for production.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ To deploy UAT/Science/Production, first ensure `montagu-deploy` is installed:
 
 Then start the required instance, e.g.:
 
-    montagu start uat
+    montagu start <path>
+
+Where `<path>` is the path to one of the configuration directories in this repository (ie. `uat`, `science` or `production`).
 
 See https://github.com/vimc/montagu-deploy for more details on the deploy tool.
 
@@ -23,6 +25,16 @@ See https://github.com/vimc/montagu-deploy for more details on the deploy tool.
 
 After deploying both Montagu AND OrderlyWeb, you may need to copy the data viz tools into place. This can be done
 with `./scripts/copy-vis-tool.sh`.
+
+# Automatic certificate renewal
+
+If automatic certificates are enabled, you should run the `renew-certificate` the first time you deploy montagu to get the initial certificate.
+
+    montagu renew-certificate <path>
+
+This command will need to be run periodically to ensure the certificate stays up-to-date. This is done by installing a systemd timer, using the provided `install-timer.sh` script.
+
+    ./scripts/install-timer.sh <path>
 
 # Backup and restore
 

--- a/production/montagu.yml
+++ b/production/montagu.yml
@@ -31,6 +31,9 @@ volumes:
   static: montagu_static_volume
   static_logs: montagu_static_logs
   mq: montagu_mq
+  acme-challenge: montagu_acme_challenge
+  certificates: montagu_certificates
+  certbot: montagu_certbot
 
 api:
   name: montagu-api
@@ -82,17 +85,17 @@ db:
     - role_permission
 proxy:
   name: montagu-reverse-proxy
-  tag: vimc-7152
+  tag: master
   port_http: 80
   port_https: 443
   metrics:
     repo: nginx
     name: nginx-prometheus-exporter
-    tag: 0.10.0
-  ssl:
-    key: VAULT:secret/vimc/ssl/v2/production/key:value
-    certificate: VAULT:secret/vimc/ssl/v2/production/cert:value
-    dhparam: VAULT:secret/vimc/ssl/v2/production/dhparam:value
+    tag: 1.3.0
+  acme:
+    email: reside@imperial.ac.uk
+    additional_domains:
+      - production2.montagu.dide.ic.ac.uk
 contrib:
   name: montagu-contrib-portal
   tag: master

--- a/scripts/install-timer.sh
+++ b/scripts/install-timer.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo >&2 "Usage: $0 CONFIG"
+    exit 1
+fi
+
+HERE=$(realpath "$(dirname $0)")
+CONFIG="$(realpath $1)"
+
+if [[ ! -f $CONFIG/montagu.yml ]]; then
+    echo >&2 "$1 is not a valid montagu configuration path"
+    exit 1
+fi
+
+if ! MONTAGU="$(which montagu)"; then
+    echo >&2 "Could not locate the montagu deployment tool"
+    exit 1
+fi
+
+# these need to be exported for envsubst
+export CONFIG MONTAGU
+
+echo >&2 "Installing systemd units..."
+envsubst < $HERE/systemd/montagu-renew-certificate.service | \
+    sudo install -T -m644 /dev/stdin /etc/systemd/system/montagu-renew-certificate.service
+sudo install -T -m644 $HERE/systemd/montagu-renew-certificate.timer /etc/systemd/system/montagu-renew-certificate.timer
+
+echo >&2 "Enabling timer..."
+sudo systemctl daemon-reload
+sudo systemctl enable --now montagu-renew-certificate.timer
+
+sudo systemctl status --no-pager montagu-renew-certificate.timer

--- a/scripts/systemd/montagu-renew-certificate.service
+++ b/scripts/systemd/montagu-renew-certificate.service
@@ -1,0 +1,4 @@
+[Service]
+Type=oneshot
+User=$USER
+ExecStart=$MONTAGU renew-certificate $CONFIG

--- a/scripts/systemd/montagu-renew-certificate.timer
+++ b/scripts/systemd/montagu-renew-certificate.timer
@@ -1,0 +1,6 @@
+[Timer]
+OnCalendar=daily
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
The certificate is renewed using the `montagu renew-certificate` command. A system timer and one-shot service are used to do this periodically. While the timer is set to run daily, in practice certbot checks the existing certificate, and only renews it if the certificate is due to expire in the next 30 days..