### PR TITLE
Update packages.yml to reflect ggbump status

### DIFF
--- a/packages/packages.yml
+++ b/packages/packages.yml
@@ -117,7 +117,7 @@ packages:
   - getPass
   - gfonts
   # - ggalt - currently Archived on CRAN
-  - ggbump
+  # - ggbump - currently Archived on CRAN
   - ggdist
   - ggforce
   - ggfun
@@ -350,5 +350,6 @@ github:
   - adletaw/captioner
   - nfultz/stackoverflow
   - cran/ggalt
+  - davidsjoberg/ggbump
   - vimc/vacsce
   - whocov/whomapper


### PR DESCRIPTION
Commented out ggbump due to its archived status on CRAN and add it to the list of packages to fetch from alternative sources.

Unfortunately, CRAN continues with an inspired strategy of removing packages in order to keep CRAN reliable, so we have to find temporary(?) installation sources for this week's unloved packages.

This new packages.yml was able to install successfully on uat.